### PR TITLE
Fix broken links to Metamorphosis chapter in Being Classes pages

### DIFF
--- a/manuals/1.0/en/03-being-classes.md
+++ b/manuals/1.0/en/03-being-classes.md
@@ -37,7 +37,7 @@ final readonly class ValidatedUser
 }
 ```
 
-`#[Input]` parameters automatically receive values from the previous class's public properties by matching names. `UserInput`'s `public string $name` maps to `ValidatedUser`'s `#[Input] string $name`. `#[Inject]` parameters receive external dependencies from the DI container. The detailed rules of this automatic matching are explained in [Chapter 5: Metamorphosis](./05-metamorphosis-patterns.html).
+`#[Input]` parameters automatically receive values from the previous class's public properties by matching names. `UserInput`'s `public string $name` maps to `ValidatedUser`'s `#[Input] string $name`. `#[Inject]` parameters receive external dependencies from the DI container. The detailed rules of this automatic matching are explained in [Chapter 5: Metamorphosis](./05-metamorphosis.html).
 
 ## Objects as Temporal Beings
 

--- a/manuals/1.0/ja/03-being-classes.md
+++ b/manuals/1.0/ja/03-being-classes.md
@@ -39,7 +39,7 @@ final readonly class ValidatedUser
 }
 ```
 
-`#[Input]`パラメータには、前のクラスのpublicプロパティが名前の一致により自動的に渡されます。`UserInput`の`public string $name`は`ValidatedUser`の`#[Input] string $name`に対応します。`#[Inject]`パラメータにはDIコンテナから外部の依存が注入されます。この自動マッチングの詳細なルールは[5章 変容](./05-metamorphosis-patterns.html)で説明します。
+`#[Input]`パラメータには、前のクラスのpublicプロパティが名前の一致により自動的に渡されます。`UserInput`の`public string $name`は`ValidatedUser`の`#[Input] string $name`に対応します。`#[Inject]`パラメータにはDIコンテナから外部の依存が注入されます。この自動マッチングの詳細なルールは[5章 変容](./05-metamorphosis.html)で説明します。
 
 ## 時間的存在としてのオブジェクト
 


### PR DESCRIPTION
## Summary

- 03-being-classes.md（日英）の変容章へのリンクを修正
- `./05-metamorphosis-patterns.html` → `./05-metamorphosis.html`

05-metamorphosis-patterns.md の permalink は `05-metamorphosis.html` であり、ファイル名ベースの `05-metamorphosis-patterns.html` は存在しない。

## Test plan
- [ ] Jekyll buildが通ること
- [ ] 日英の Being Classes ページから Metamorphosis 章へのリンクが正しく遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected chapter reference links in the "Being Classes" section of the manual documentation for both English and Japanese versions. Updated cross-references to point to the correct chapter file, improving documentation navigation and consistency across all supported languages. These changes ensure users can reliably access related chapter materials without encountering broken or incorrect links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->