### PR TITLE
Landing: add I Ching epigraph and emphasize transforms / nature / destiny

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,16 @@ category: Index
 <div class="jumbotron">
     <div><img src="./images/logo.png" alt="logo" width="256 px"></div>
 <!--    <div style="font-size: xxx-large; font-family: 'Arial Black',serif">Be Framework</div>-->
-    <p style="font-size: 1.8rem;">
+    <span class="sr-only">乾道變化、各正性命 — I Ching, Commentary on the Hexagram Qián (Circa 4th Century BC)</span>
+    <p style="font-size: 1.8rem; white-space: nowrap;">
+        <br>
+        As the Way <strong>transforms</strong>, each thing settles into its <strong>nature</strong> and <strong>destiny</strong>.
         <br>
         The Being-Oriented Framework for PHP
     </p>
 
     <a class="intl btn btn-primary" href="/manuals/1.0/en/index.html">
-        Learn more &raquo;
+        be &raquo;
     </a>
     <script>
         window.addEventListener('DOMContentLoaded', (event) => {

--- a/index.html
+++ b/index.html
@@ -7,7 +7,13 @@ category: Index
     <div><img src="./images/logo.png" alt="logo" width="256 px"></div>
 <!--    <div style="font-size: xxx-large; font-family: 'Arial Black',serif">Be Framework</div>-->
     <span class="sr-only">乾道變化、各正性命 — I Ching, Commentary on the Hexagram Qián (Circa 4th Century BC)</span>
-    <p style="font-size: 1.8rem; white-space: nowrap;">
+    <style>
+        .hero-tagline { font-size: 1.8rem; }
+        @media (min-width: 1200px) {
+            .hero-tagline { white-space: nowrap; }
+        }
+    </style>
+    <p class="hero-tagline">
         <br>
         As the Way <strong>transforms</strong>, each thing settles into its <strong>nature</strong> and <strong>destiny</strong>.
         <br>


### PR DESCRIPTION
## Summary

Reframes the landing tagline around the three Be Framework keywords (**transforms**, **nature**, **destiny**) and roots them in the original source — *乾道變化、各正性命* (I Ching, Commentary on the Hexagram Qián, circa 4th Century BC).

- The Chinese line is rendered as `<span class="sr-only">` — invisible but indexed by search engines and accessible to screen readers.
- The English line is the one visitors see, with the three load-bearing words bolded (mirrors BEAR.Sunday's landing emphasis style).
- CTA shortened to `be »`.
- `white-space: nowrap` keeps the longer line on a single row.

## Test plan

- [ ] Render at `/index.html` and confirm the new line displays on one row at desktop widths.
- [ ] View source / inspect — the `sr-only` Chinese line is present in HTML.
- [ ] Locale toggle still rewrites `/en/` → `/ja/` for the CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added screen reader-only content with contextual information to enhance experience for users utilizing assistive technologies.

* **Content Updates**
  * Refreshed hero section messaging with newly emphasized key terms and improved text formatting.
  * Updated primary call-to-action button label for clearer user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->