### PR TITLE
Align the tutorial with the app skeleton flow

### DIFF
--- a/manuals/1.0/en/tutorial.md
+++ b/manuals/1.0/en/tutorial.md
@@ -17,14 +17,14 @@ permalink: /manuals/1.0/en/tutorial.html
 
 ## Introduction
 
-In this tutorial, we'll build an emergency triage system that demonstrates the core philosophy of Be Framework: **objects don't DO things—they BECOME things.**
+This tutorial picks up from [Getting Started](./getting-started.html) and builds an emergency triage system that demonstrates the core philosophy of Be Framework: **objects don't DO things—they BECOME things.**
 
 A patient doesn't "get triaged." They **become** an emergency case or an observation case, based on the transcendent wisdom of medical protocol.
 
 ## The Metamorphosis
 
 ```
-PatientArrival (raw vital signs)
+PatientArrivalInput (raw vital signs)
     ↓ JTAS Protocol assesses
 TriageAssessment (the chrysalis stage)
     ↓ Destiny is determined
@@ -129,10 +129,10 @@ This is the **Reason**—the external force that enables metamorphosis. Just as 
 The starting point—raw vital signs at the moment of arrival:
 
 ```php
-// src/Input/PatientArrival.php
+// src/Input/PatientArrivalInput.php
 
 #[Be([TriageAssessment::class])]
-final readonly class PatientArrival
+final readonly class PatientArrivalInput
 {
     public function __construct(
         public float $bodyTemperature,
@@ -263,32 +263,32 @@ Each type has different methods. `EmergencyCase` can `assignER()`, while `Observ
 
 ## Step 8: Execute the Metamorphosis
 
-```php
-// bin/be.php
+Keep the skeleton's generic `bin/be.php` entrypoint and invoke your new input by path:
 
-use Be\App\Input\PatientArrival;
-use Be\App\Module\AppModule;
-use Be\Framework\Becoming;
-use Ray\Di\Injector;
-
-$injector = new Injector(new AppModule());
-$becoming = new Becoming($injector, 'Be\\App\\Semantic');
-
-// High fever patient
-$patient = new PatientArrival(bodyTemperature: 39.5, heartRate: 90);
-$final = $becoming($patient);
-
-echo $final->priority;     // "IMMEDIATE"
-echo $final->color;        // "RED"
-echo $final->assignER();   // "Secure ER Room 1 immediately..."
+```bash
+php bin/be.php 'patientArrival?bodyTemperature=39.5&heartRate=90'
 ```
+
+Output:
+
+```json
+{
+  "priority": "IMMEDIATE",
+  "color": "RED",
+  "bodyTemperature": 39.5,
+  "heartRate": 90,
+  "being": {}
+}
+```
+
+`bin/be.php` maps the URI path `patientArrival` to `Be\App\Input\PatientArrivalInput`, parses the query string, and runs the same metamorphosis pipeline you used in Getting Started.
 
 ## Temporal Existence
 
 All existence flows through time—from Input through Being to Final.
 
 ```
-PatientArrival(39.5°C, 90 bpm)
+PatientArrivalInput(39.5°C, 90 bpm)
     ↓ #[Be([TriageAssessment::class])]
 TriageAssessment
     ├─ JTASProtocol->assess() returns 'emergency'
@@ -302,16 +302,14 @@ EmergencyCase (because $being is Emergency)
 
 ## Handling Non-Survivable Existence
 
-```php
-// Temperature outside survivable range
-$invalid = new PatientArrival(bodyTemperature: 50.0, heartRate: 80);
+```bash
+php bin/be.php 'patientArrival?bodyTemperature=50.0&heartRate=80'
+```
 
-try {
-    $becoming($invalid);
-} catch (SemanticVariableException $e) {
-    echo $e->getErrors()->getMessages('en')[0];
-    // "Vital signs indicate non-survivable conditions."
-}
+Output:
+
+```txt
+Vital signs indicate non-survivable conditions.
 ```
 
 The metamorphosis is **rejected**. A patient with lethal vital signs cannot exist in our system.
@@ -336,7 +334,7 @@ Problems:
 ### Be Framework Approach (Being)
 
 ```php
-$patient = new PatientArrival($temp, $hr);
+$patient = new PatientArrivalInput($temp, $hr);
 $final = $becoming($patient);
 
 // $final IS an EmergencyCase or ObservationCase
@@ -360,7 +358,7 @@ src/
 ├── Exception/
 │   └── LethalVitalException.php
 ├── Input/
-│   └── PatientArrival.php      # Entry point
+│   └── PatientArrivalInput.php # Entry point
 ├── Module/
 │   └── AppModule.php           # DI configuration
 ├── Final/
@@ -387,7 +385,7 @@ The same pattern applies everywhere:
 
 | Domain | Input | Being | Final | Reason |
 |--------|-------|-------|---------|--------|
-| Triage | PatientArrival | TriageAssessment | Emergency/Observation | JTASProtocol |
+| Triage | PatientArrivalInput | TriageAssessment | Emergency/Observation | JTASProtocol |
 | Brewing | RawMaterials | Fermentation | PremiumSake/Vinegar | YeastCulture |
 | Immigration | VisaApplication | ConsularReview | Resident/Visitor | ImmigrationLaw |
 | Justice | Evidence | Trial | Guilty/Acquitted | PenalCode |

--- a/manuals/1.0/ja/tutorial.md
+++ b/manuals/1.0/ja/tutorial.md
@@ -17,14 +17,14 @@ permalink: /manuals/1.0/ja/tutorial.html
 
 ## はじめに
 
-このチュートリアルでは、Be Framework の核心を示す救急トリアージシステムを構築します：オブジェクトは何かを「する」のではなく、何かに「なる」のです。
+このチュートリアルは [Getting Started](./getting-started.html) の続きとして、Be Framework の核心を示す救急トリアージシステムを構築します：オブジェクトは何かを「する」のではなく、何かに「なる」のです。
 
 患者は「トリアージされる」のではありません。医学プロトコルという患者自身は持たない(=超越的な)知恵に基づいて、緊急症例または経過観察症例に**なる**のです。
 
 ## 変容の流れ
 
 ```
-PatientArrival（生のバイタルサイン）
+PatientArrivalInput（生のバイタルサイン）
     ↓ JTAS プロトコルが評価
 TriageAssessment（蛹の段階）
     ↓ 運命が決定される
@@ -129,10 +129,10 @@ final readonly class JTASProtocol
 出発点—到着時の生のバイタルサイン：
 
 ```php
-// src/Input/PatientArrival.php
+// src/Input/PatientArrivalInput.php
 
 #[Be([TriageAssessment::class])]
-final readonly class PatientArrival
+final readonly class PatientArrivalInput
 {
     public function __construct(
         public float $bodyTemperature,
@@ -264,32 +264,32 @@ final readonly class ObservationCase
 
 ## ステップ 8: 変容を実行
 
-```php
-// bin/be.php
+スケルトンの汎用 `bin/be.php` エントリポイントはそのまま使い、新しい input を path で呼び出します。
 
-use Be\App\Input\PatientArrival;
-use Be\App\Module\AppModule;
-use Be\Framework\Becoming;
-use Ray\Di\Injector;
-
-$injector = new Injector(new AppModule());
-$becoming = new Becoming($injector, 'Be\\App\\Semantic');
-
-// 高熱の患者
-$patient = new PatientArrival(bodyTemperature: 39.5, heartRate: 90);
-$final = $becoming($patient);
-
-echo $final->priority;     // "IMMEDIATE"
-echo $final->color;        // "RED"
-echo $final->assignER();   // "直ちに救急室1を確保..."
+```bash
+php bin/be.php 'patientArrival?bodyTemperature=39.5&heartRate=90'
 ```
+
+出力:
+
+```json
+{
+  "priority": "IMMEDIATE",
+  "color": "RED",
+  "bodyTemperature": 39.5,
+  "heartRate": 90,
+  "being": {}
+}
+```
+
+`bin/be.php` は URI の path `patientArrival` を `Be\App\Input\PatientArrivalInput` にマップし、query string を constructor 引数として渡して、Getting Started と同じ変容パイプラインを実行します。
 
 ## 時間的存在
 
 すべての存在は時間の中で変化し、Input から Being を経て Final へと変容します。
 
 ```
-PatientArrival(39.5°C, 90 bpm)
+PatientArrivalInput(39.5°C, 90 bpm)
     ↓ #[Be([TriageAssessment::class])]
 TriageAssessment
     ├─ JTASProtocol->assess() が 'emergency' を返す
@@ -303,16 +303,14 @@ EmergencyCase（$being が Emergency なので）
 
 ## 生存不可能な存在
 
-```php
-// 生存可能範囲外の体温
-$invalid = new PatientArrival(bodyTemperature: 50.0, heartRate: 80);
+```bash
+php bin/be.php 'patientArrival?bodyTemperature=50.0&heartRate=80'
+```
 
-try {
-    $becoming($invalid);
-} catch (SemanticVariableException $e) {
-    echo $e->getErrors()->getMessages('ja')[0];
-    // "バイタルサインが生存不可能な状態を示しています。"
-}
+出力:
+
+```txt
+バイタルサインが生存不可能な状態を示しています。
 ```
 
 変容は拒否されます。致死的なバイタルサインを持つ患者は私たちのシステムに存在できません。
@@ -337,7 +335,7 @@ if ($triageService->isEmergency($patient)) {
 ### Be Framework のアプローチ（Being）
 
 ```php
-$patient = new PatientArrival($temp, $hr);
+$patient = new PatientArrivalInput($temp, $hr);
 $final = $becoming($patient);
 
 // $final は EmergencyCase または ObservationCase である
@@ -361,7 +359,7 @@ src/
 ├── Exception/
 │   └── LethalVitalException.php
 ├── Input/
-│   └── PatientArrival.php      # 入力
+│   └── PatientArrivalInput.php # 入力
 ├── Module/
 │   └── AppModule.php           # DI設定
 ├── Final/
@@ -388,7 +386,7 @@ src/
 
 | ドメイン | Input | Being | Final | Reason |
 |---------|-------|-------|-------|--------|
-| トリアージ | PatientArrival | TriageAssessment | Emergency/Observation | JTASProtocol |
+| トリアージ | PatientArrivalInput | TriageAssessment | Emergency/Observation | JTASProtocol |
 | 醸造 | RawMaterials | Fermentation | PremiumSake/Vinegar | YeastCulture |
 | 入国審査 | VisaApplication | ConsularReview | Resident/Visitor | ImmigrationLaw |
 | 裁判 | Evidence | Trial | Guilty/Acquitted | PenalCode |


### PR DESCRIPTION
## Summary
- make the tutorial use the `Be\App` namespace expected by the current skeleton direction
- rename the example input class to `PatientArrivalInput` so it matches `bin/be.php` path-to-class resolution
- replace the pseudo `bin/be.php` rewrite step with the actual URI-style invocation that was verified locally

## Verification
- practiced the tutorial flow in a temporary app copied from `be-skeleton`
- verified `php bin/be.php 'patientArrival?bodyTemperature=39.5&heartRate=90'`
- verified `php bin/be.php 'patientArrival?bodyTemperature=37.0&heartRate=80'`
- verified the lethal-vital error case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial examples to use CLI invocation with URI-style paths instead of direct code execution.
  * Renamed input object for improved naming clarity.
  * Changed code examples and expected outputs to show JSON and text formats.
  * Updated tutorial content across multiple language versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->