### PR TITLE
Improve locale-aware manual links

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,12 +43,22 @@ category: Index
         be &raquo;
     </a>
     <script>
-        window.addEventListener('DOMContentLoaded', (event) => {
+        window.addEventListener('DOMContentLoaded', () => {
+            const navigatorLanguages = window.navigator.languages;
+            const locales = (navigatorLanguages && navigatorLanguages.length)
+                ? navigatorLanguages
+                : [window.navigator.language ?? ''];
+            const prefersJapanese = locales.some((locale) => locale.toLowerCase().startsWith('ja'));
+
+            if (!prefersJapanese) {
+                return;
+            }
+
             const links = document.getElementsByClassName('intl');
-            const locale = window.navigator.language;
-            if (locale.startsWith('ja')) {
-                for(let i = 0; i < links.length; i++) {
-                    links[i].setAttribute('href', links[i].getAttribute('href').replace('/en/', '/ja/'));
+            for (const link of links) {
+                const href = link.getAttribute('href');
+                if (href && href.includes('/en/')) {
+                    link.setAttribute('href', href.replace('/en/', '/ja/'));
                 }
             }
         });


### PR DESCRIPTION
## What changed

- updated the landing-page locale helper to use navigator.languages with navigator.language fallback
- kept the manual entry link English by default and switched it to Japanese only for Japanese-preferring browsers

## Why

- this aligns the site with the newer locale handling used across the manual sites
- it improves browser-language matching without changing the underlying URL structure

## Notes

- this PR contains only the locale-link commit and is based on master
- git pull could not be completed from this environment because github.com DNS resolution failed at the time of execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Japanese language detection to check the user's browser language preferences more comprehensively
  * Improved localization routing to accurately update navigation links for Japanese content when applicable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->